### PR TITLE
removed unneeded uses of Lift2

### DIFF
--- a/src/Bound/Scope.hs
+++ b/src/Bound/Scope.hs
@@ -129,21 +129,21 @@ instance (Monad f, Eq b, Eq1 f, Eq a) => Eq  (Scope b f a) where
   (==) = (==#)
   {-# INLINE (==) #-}
 instance (Monad f, Eq b, Eq1 f)       => Eq1 (Scope b f)   where
-  a ==# b = liftM Lift2 (fromScope a) ==# liftM Lift2 (fromScope b)
+  a ==# b = fromScope a ==# fromScope b
   {-# INLINE (==#) #-}
 
 instance (Monad f, Ord b, Ord1 f, Ord a) => Ord  (Scope b f a) where
   compare = compare1
   {-# INLINE compare #-}
 instance (Monad f, Ord b, Ord1 f)        => Ord1 (Scope b f) where
-  compare1 a b = liftM Lift2 (fromScope a) `compare1` liftM Lift2 (fromScope b)
+  compare1 a b = fromScope a `compare1` fromScope b
   {-# INLINE compare1 #-}
 
 instance (Functor f, Show b, Show1 f, Show a) => Show (Scope b f a) where
   showsPrec = showsPrec1
 instance (Functor f, Show b, Show1 f) => Show1 (Scope b f) where
   showsPrec1 d a = showParen (d > 10) $
-    showString "Scope " . showsPrec1 11 (fmap (Lift2 . fmap Lift1) (unscope a))
+    showString "Scope " . showsPrec1 11 (fmap (fmap Lift1) (unscope a))
 
 instance (Functor f, Read b, Read1 f, Read a) => Read  (Scope b f a) where
   readsPrec = readsPrec1
@@ -151,7 +151,7 @@ instance (Functor f, Read b, Read1 f)         => Read1 (Scope b f) where
   readsPrec1 d = readParen (d > 10) $ \r -> do
     ("Scope", r') <- lex r
     (s, r'') <- readsPrec1 11 r'
-    return (Scope (fmap (fmap lower1 . lower2) s), r'')
+    return (Scope (fmap (fmap lower1) s), r'')
 
 instance Bound (Scope b) where
   Scope m >>>= f = Scope (liftM (fmap (>>= f)) m)

--- a/src/Bound/Scope/Simple.hs
+++ b/src/Bound/Scope/Simple.hs
@@ -123,21 +123,21 @@ instance (Functor f, Eq b, Eq1 f, Eq a) => Eq  (Scope b f a) where
   (==) = (==#)
   {-# INLINE (==) #-}
 instance (Functor f, Eq b, Eq1 f)       => Eq1 (Scope b f)   where
-  a ==# b = fmap Lift2 (unscope a) ==# fmap Lift2 (unscope b)
+  a ==# b = unscope a ==# unscope b
   {-# INLINE (==#) #-}
 
 instance (Functor f, Ord b, Ord1 f, Ord a) => Ord  (Scope b f a) where
   compare = compare1
   {-# INLINE compare #-}
 instance (Functor f, Ord b, Ord1 f)        => Ord1 (Scope b f) where
-  compare1 a b = fmap Lift2 (unscope a) `compare1` fmap Lift2 (unscope b)
+  compare1 a b = unscope a `compare1` unscope b
   {-# INLINE compare1 #-}
 
 instance (Functor f, Show b, Show1 f, Show a) => Show (Scope b f a) where
   showsPrec = showsPrec1
 instance (Functor f, Show b, Show1 f) => Show1 (Scope b f) where
   showsPrec1 d a = showParen (d > 10) $
-    showString "Scope " . showsPrec1 11 (fmap Lift2 (unscope a))
+    showString "Scope " . showsPrec1 11 (unscope a)
 
 instance (Functor f, Read b, Read1 f, Read a) => Read  (Scope b f a) where
   readsPrec = readsPrec1


### PR DESCRIPTION
The uses of `Lift2` were always for types of the form `Lift2 Var X Y`, so the instances obtained for them were the same as the ones for `Var X Y`.

In particular we keep the intended meaning for Scope equality:

```
*Bound.Scope> let xs = abstract1 'a' "ab" >>>= \x -> [x,x]
*Bound.Scope> xs == toScope (fromScope xs) 
True
*Bound.Scope> xs 
Scope [B (),F "bb"]
*Bound.Scope> toScope (fromScope xs) 
Scope [B (),F "b",F "b"]
```

Lift1 can't be removed instead, because we need `C (f a)` instances with only `C1 f` in the context.
