### PR TITLE
Add abstraction functions

### DIFF
--- a/src/Bound/Name.hs
+++ b/src/Bound/Name.hs
@@ -36,6 +36,8 @@ module Bound.Name
   , _Name
   , name
   , abstractName
+  , abstractEName
+  , abstractAllName
   , abstract1Name
   , instantiateName
   , instantiate1Name
@@ -251,6 +253,20 @@ abstractName f t = Scope (liftM k t) where
 abstract1Name :: (Monad f, Eq a) => a -> f a -> Scope (Name a ()) f a
 abstract1Name a = abstractName (\b -> if a == b then Just () else Nothing)
 {-# INLINE abstract1Name #-}
+
+-- | Capture some free variables in an expression to yield
+-- a 'Scope' with named bound variables. Optionally change the
+-- types of the remaining free variables.
+abstractEName :: Monad f => (a -> Either a' b) -> f a -> Scope (Name a b) f a'
+abstractEName f e = Scope (liftM k e) where
+  k y = case f y of
+    Right z -> B (Name y z)
+    Left y' -> F (return y')
+
+-- | Capture all the free variables in an expression to yield
+-- a 'Scope' with named bound variables in @b@.
+abstractAllName :: Monad f => (a -> b) -> f a -> Scope (Name a b) f c
+abstractAllName f = abstractEName (Right . f)
 
 -------------------------------------------------------------------------------
 -- Instantiation

--- a/src/Bound/Scope.hs
+++ b/src/Bound/Scope.hs
@@ -34,7 +34,7 @@
 module Bound.Scope
   ( Scope(..)
   -- * Abstraction
-  , abstract, abstract1
+  , abstract, abstractE, abstract1, abstractAll
   -- * Instantiation
   , instantiate, instantiate1
   -- * Traditional de Bruijn
@@ -261,6 +261,20 @@ abstract f e = Scope (liftM k e) where
     Just z  -> B z
     Nothing -> F (return y)
 {-# INLINE abstract #-}
+
+-- | Capture some free variables in an expression to yield
+-- a 'Scope' with bound variables in @b@. Optionally change the
+-- types of the remaining free variables.
+abstractE :: Monad f => (a -> Either a' b) -> f a -> Scope b f a'
+abstractE f e = Scope (liftM k e) where
+  k y = case f y of
+    Right z -> B z
+    Left y' -> F (return y')
+
+-- | Capture all the free variables in an expression to yield
+-- a 'Scope' with bound variables in @b@.
+abstractAll :: Monad f => (a -> b) -> f a -> Scope b f c
+abstractAll f = abstractE (Right . f)
 
 -- | Abstract over a single variable
 --


### PR DESCRIPTION
* `abstractE :: Monad f => (a -> Either a' b) -> f a -> Scope b f a'`

* @phadej noted that this could be defined in terms of `abstractE`, so
I figured I'd just go ahead and do that.
  `abstractAll :: Monad f => (a -> b) -> f a -> Scope b f c`

Implements #46