### PR TITLE
Add more generic instances

### DIFF
--- a/src/Bound/Class.hs
+++ b/src/Bound/Class.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE CPP #-}
-#if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 704
+#if defined(__GLASGOW_HASKELL__)
 {-# LANGUAGE DefaultSignatures #-}
 #endif
 {-# OPTIONS -fno-warn-deprecations #-}
@@ -20,10 +20,8 @@ module Bound.Class
   , (=<<<)
   ) where
 
-#if __GLASGOW_HASKELL__ >= 704
 import Control.Monad.Trans.Class
-#endif
-#if __GLASGOW_HASKELL__ < 710
+#if !MIN_VERSION_base(4,8,0)
 import Data.Monoid
 #endif
 import Control.Monad.Trans.Cont
@@ -67,7 +65,7 @@ class Bound t where
   --
   -- @m '>>>=' f = m '>>=' 'lift' '.' f@
   (>>>=) :: Monad f => t f a -> (a -> f c) -> t f c
-#if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 704
+#if defined(__GLASGOW_HASKELL__)
   default (>>>=) :: (MonadTrans t, Monad f, Monad (t f)) =>
                     t f a -> (a -> f c) -> t f c
   m >>>= f = m >>= lift . f

--- a/src/Bound/Name.hs
+++ b/src/Bound/Name.hs
@@ -93,6 +93,9 @@ data Name n b = Name n b deriving
 # if __GLASGOW_HASKELL__ >= 704
   , Generic
 # endif
+# if __GLASGOW_HASKELL__ >= 706
+  , Generic1
+#endif
 #endif
   )
 

--- a/src/Bound/Name.hs
+++ b/src/Bound/Name.hs
@@ -1,16 +1,10 @@
 {-# LANGUAGE CPP #-}
 #ifdef __GLASGOW_HASKELL__
 {-# LANGUAGE DeriveDataTypeable #-}
-
-# if __GLASGOW_HASKELL__ >= 704
 {-# LANGUAGE DeriveGeneric #-}
-# endif
-
-#if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 702
 {-# LANGUAGE Trustworthy #-}
 #endif
 
-#endif
 -----------------------------------------------------------------------------
 -- |
 -- Copyright   :  (C) 2012 Edward Kmett
@@ -45,17 +39,15 @@ module Bound.Name
 
 import Bound.Scope
 import Bound.Var
-#if __GLASGOW_HASKELL__ < 710
+#if !MIN_VERSION_base(4,8,0)
 import Control.Applicative
-#endif
-import Control.Comonad
-import Control.DeepSeq
-import Control.Monad (liftM, liftM2)
-#if __GLASGOW_HASKELL__ < 710
 import Data.Foldable
 import Data.Monoid
 import Data.Traversable
 #endif
+import Control.Comonad
+import Control.DeepSeq
+import Control.Monad (liftM, liftM2)
 import Data.Bifunctor
 import Data.Bifoldable
 import qualified Data.Binary as Binary
@@ -65,9 +57,7 @@ import Data.Bytes.Serial
 import Data.Functor.Classes
 #ifdef __GLASGOW_HASKELL__
 import Data.Data
-# if __GLASGOW_HASKELL__ >= 704
 import GHC.Generics
-# endif
 #endif
 import Data.Hashable (Hashable(..))
 import Data.Hashable.Lifted (Hashable1(..), Hashable2(..))
@@ -90,9 +80,7 @@ data Name n b = Name n b deriving
 #ifdef __GLASGOW_HASKELL__
   , Typeable
   , Data
-# if __GLASGOW_HASKELL__ >= 704
   , Generic
-# endif
 # if __GLASGOW_HASKELL__ >= 706
   , Generic1
 #endif
@@ -236,9 +224,8 @@ instance (Serialize b, Serialize a) => Serialize (Name b a) where
   put = serializeWith2 Serialize.put Serialize.put
   get = deserializeWith2 Serialize.get Serialize.get
 
-# if __GLASGOW_HASKELL__ >= 704
-instance (NFData b, NFData a) => NFData (Name b a)
-# endif
+instance (NFData b, NFData a) => NFData (Name b a) where
+  rnf (Name a b) = rnf a `seq` rnf b
 
 -------------------------------------------------------------------------------
 -- Abstraction

--- a/src/Bound/Scope.hs
+++ b/src/Bound/Scope.hs
@@ -6,17 +6,8 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE UndecidableInstances #-}
-#if __GLASGOW_HASKELL__ >= 702
 {-# LANGUAGE Trustworthy #-}
-#endif
-#if __GLASGOW_HASKELL__ >= 704
 {-# LANGUAGE DeriveGeneric #-}
-#endif
-
-#endif
-
-#ifndef MIN_VERSION_base
-#define MIN_VERSION_base(x,y,z) 1
 #endif
 
 -----------------------------------------------------------------------------
@@ -95,7 +86,7 @@ import Data.Data
 #if defined(__GLASGOW_HASKELL__)
 #if __GLASGOW_HASKELL__ >= 706
 import GHC.Generics ( Generic, Generic1 )
-#elif __GLASGOW_HASKELL__ >= 704
+#else
 import GHC.Generics ( Generic )
 #endif
 #endif
@@ -128,18 +119,13 @@ import GHC.Generics ( Generic )
 --
 newtype Scope b f a = Scope { unscope :: f (Var b (f a)) }
 #if defined(__GLASGOW_HASKELL__)
-  deriving
-           (
-#if __GLASGOW_HASKELL__ >= 707
-             Typeable
-#endif
-#if __GLASGOW_HASKELL__ >= 704
-           , Generic
+  deriving (Generic)
+#if (__GLASGOW_HASKELL__ >= 707) && (__GLASGOW_HASKELL__ < 800)
+deriving instance Typeable Scope
 #endif
 #if __GLASGOW_HASKELL__ >= 706
-           , Generic1
+deriving instance Functor f => Generic1 (Scope b f)
 #endif
-           )
 #endif
 
 -------------------------------------------------------------------------------
@@ -168,7 +154,7 @@ instance (Functor f, Monad f) => Applicative (Scope b f) where
 -- | The monad permits substitution on free variables, while preserving
 -- bound variables
 instance Monad f => Monad (Scope b f) where
-#if __GLASGOW_HASKELL__ < 710
+#if !MIN_VERSION_base(4,8,0)
   return a = Scope (return (F (return a)))
   {-# INLINE return #-}
 #endif
@@ -182,7 +168,7 @@ instance MonadTrans (Scope b) where
   {-# INLINE lift #-}
 
 instance MFunctor (Scope b) where
-#if __GLASGOW_HASKELL__ < 710
+#if !MIN_VERSION_base(4,8,0)
   hoist t (Scope b) = Scope $ t (liftM (liftM t) b)
 #else
   hoist = hoistScope

--- a/src/Bound/Scope.hs
+++ b/src/Bound/Scope.hs
@@ -6,9 +6,11 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE UndecidableInstances #-}
-
 #if __GLASGOW_HASKELL__ >= 702
 {-# LANGUAGE Trustworthy #-}
+#endif
+#if __GLASGOW_HASKELL__ >= 704
+{-# LANGUAGE DeriveGeneric #-}
 #endif
 
 #endif
@@ -90,6 +92,13 @@ import Data.Serialize (Serialize)
 import Data.Traversable
 import Prelude hiding (foldr, mapM, mapM_)
 import Data.Data
+#if defined(__GLASGOW_HASKELL__)
+#if __GLASGOW_HASKELL__ >= 706
+import GHC.Generics ( Generic, Generic1 )
+#elif __GLASGOW_HASKELL__ >= 704
+import GHC.Generics ( Generic )
+#endif
+#endif
 
 -- $setup
 -- >>> import Bound.Var
@@ -118,8 +127,19 @@ import Data.Data
 -- @f (Var b a)@, but the extra @f a@ inside permits us a cheaper 'lift'.
 --
 newtype Scope b f a = Scope { unscope :: f (Var b (f a)) }
-#if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 707
-  deriving Typeable
+#if defined(__GLASGOW_HASKELL__)
+  deriving
+           (
+#if __GLASGOW_HASKELL__ >= 707
+             Typeable
+#endif
+#if __GLASGOW_HASKELL__ >= 704
+           , Generic
+#endif
+#if __GLASGOW_HASKELL__ >= 706
+           , Generic1
+#endif
+           )
 #endif
 
 -------------------------------------------------------------------------------

--- a/src/Bound/Scope/Simple.hs
+++ b/src/Bound/Scope/Simple.hs
@@ -61,6 +61,7 @@ module Bound.Scope.Simple
 import Bound.Class
 import Bound.Var
 import Control.Applicative
+import Control.DeepSeq
 import Control.Monad hiding (mapM, mapM_)
 import Control.Monad.Morph
 import Data.Bifunctor
@@ -122,6 +123,9 @@ deriving instance Functor f => Generic1 (Scope b f)
 -------------------------------------------------------------------------------
 -- Instances
 -------------------------------------------------------------------------------
+
+instance NFData (f (Var b a)) => NFData (Scope b f a) where
+  rnf (Scope x) = rnf x
 
 instance Functor f => Functor (Scope b f) where
   fmap f (Scope a) = Scope (fmap (fmap f) a)

--- a/src/Bound/Var.hs
+++ b/src/Bound/Var.hs
@@ -87,6 +87,9 @@ data Var b a
 # if __GLASGOW_HASKELL__ >= 704
   , Generic
 # endif
+# if __GLASGOW_HASKELL__ >= 706
+  , Generic1
+#endif
 #endif
   )
 

--- a/src/Bound/Var.hs
+++ b/src/Bound/Var.hs
@@ -2,15 +2,8 @@
 
 #ifdef __GLASGOW_HASKELL__
 {-# LANGUAGE DeriveDataTypeable #-}
-
-#if __GLASGOW_HASKELL__ >= 704
 {-# LANGUAGE DeriveGeneric #-}
-#endif
-
-#if __GLASGOW_HASKELL__ >= 702
 {-# LANGUAGE Trustworthy #-}
-#endif
-
 #endif
 -----------------------------------------------------------------------------
 -- |
@@ -29,16 +22,15 @@ module Bound.Var
   , _F
   ) where
 
-#if __GLASGOW_HASKELL__ < 710
+#if !MIN_VERSION_base(4,8,0)
 import Control.Applicative
-#endif
-import Control.DeepSeq
-import Control.Monad (liftM, ap)
-#if __GLASGOW_HASKELL__ < 710
 import Data.Foldable
 import Data.Traversable
 import Data.Monoid (Monoid(..))
+import Data.Word
 #endif
+import Control.DeepSeq
+import Control.Monad (liftM, ap)
 import Data.Hashable (Hashable(..))
 import Data.Hashable.Lifted (Hashable1(..), Hashable2(..))
 import Data.Bifunctor
@@ -50,17 +42,12 @@ import Data.Bytes.Get
 import Data.Bytes.Put
 import Data.Bytes.Serial
 import Data.Functor.Classes
-#ifdef __GLASGOW_HASKELL__
-import Data.Data
-# if __GLASGOW_HASKELL__ >= 704
-import GHC.Generics
-# endif
-#endif
 import Data.Profunctor
 import qualified Data.Serialize as Serialize
 import Data.Serialize (Serialize)
-#if __GLASGOW_HASKELL__ < 710
-import Data.Word
+#ifdef __GLASGOW_HASKELL__
+import Data.Data
+import GHC.Generics
 #endif
 
 ----------------------------------------------------------------------------
@@ -84,9 +71,7 @@ data Var b a
 #ifdef __GLASGOW_HASKELL__
   , Data
   , Typeable
-# if __GLASGOW_HASKELL__ >= 704
   , Generic
-# endif
 # if __GLASGOW_HASKELL__ >= 706
   , Generic1
 #endif
@@ -254,6 +239,6 @@ instance Show b => Show1 (Var b) where showsPrec1 = showsPrec
 instance Read b => Read1 (Var b) where readsPrec1 = readsPrec
 #endif
 
-# if __GLASGOW_HASKELL__ >= 704
-instance (NFData a, NFData b) => NFData (Var b a)
-# endif
+instance (NFData a, NFData b) => NFData (Var b a) where
+  rnf (B b) = rnf b
+  rnf (F f) = rnf f


### PR DESCRIPTION
Add `Generic` and `Generic1` instances for `Scope`. Add `Generic1`
instances for `Var` and `Name`.