### PR TITLE
Docfix: Bound instances are right monad modules

### DIFF
--- a/doc/BoundLaws.hs
+++ b/doc/BoundLaws.hs
@@ -77,7 +77,7 @@ But all of the instances above respect these laws, and they are implied by
 the current law for monad transformers, we could just make them the
 Bound class laws.
 
-Btw these laws correspond to requiring (f m) to be an m-left module for every m [1],
+Btw these laws correspond to requiring (f m) to be an right m-module for every m [1],
 so we'd also get a law-abiding fmap for (f m).
 
 

--- a/src/Bound/Class.hs
+++ b/src/Bound/Class.hs
@@ -36,7 +36,7 @@ import Control.Monad.Trans.Writer
 
 infixl 1 >>>=
 
--- | Instances of 'Bound' generate left modules over monads.
+-- | Instances of 'Bound' generate right modules over monads.
 --
 -- This means they should satisfy the following laws:
 --


### PR DESCRIPTION
`(>>>= id)` gives a natural transformation `t m . m ⇒ t m,` i.e. m acts on the right.