### PR TITLE
Enforce the `template-haskell` `cabal` flag properly

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -200,3 +200,9 @@ jobs:
       - name: haddock
         run: |
           $CABAL v2-haddock $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all
+      - name: prepare for constraint sets
+        run: |
+          rm -f cabal.project.local
+      - name: constraint set no-template-haskell
+        run: |
+          $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --constraint='bound -template-haskell' all

--- a/bound.cabal
+++ b/bound.cabal
@@ -92,7 +92,6 @@ library
     mmorph           >= 1.0     && < 1.3,
     deepseq          >= 1.1     && < 1.5,
     profunctors      >= 3.3     && < 6,
-    template-haskell >= 2.7     && < 3,
     th-abstraction   >= 0.4     && < 0.5,
     transformers     >= 0.2     && < 0.6,
     transformers-compat >= 0.5  && < 1

--- a/bound.cabal
+++ b/bound.cabal
@@ -134,7 +134,7 @@ test-suite Overkill
     bound,
     transformers,
     transformers-compat,
-    functor-classes-compat,
+    functor-classes-compat < 2,
     vector
   if !impl(ghc >= 7.8)
     buildable: False

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -4,3 +4,6 @@ unconstrained:          False
 -- irc-channels:           irc.freenode.org#haskell-lens
 irc-if-in-origin-repo:  True
 docspec:                True
+
+constraint-set no-template-haskell
+  constraints: bound -template-haskell

--- a/src/Bound.hs
+++ b/src/Bound.hs
@@ -26,7 +26,7 @@
 -- import Data.Foldable
 -- import Data.Traversable
 -- -- This is from deriving-compat package
--- import Data.Deriving (deriveEq1, deriveOrd1, deriveRead1, deriveShow1) 
+-- import Data.Deriving (deriveEq1, deriveOrd1, deriveRead1, deriveShow1)
 -- @
 --
 -- @
@@ -128,8 +128,10 @@ module Bound
   , Var(..)
   , fromScope
   , toScope
-  -- * Deriving instances 
+#ifdef MIN_VERSION_template_haskell
+  -- * Deriving instances
   , makeBound
+#endif
   ) where
 
 import Bound.Var

--- a/src/Bound/TH.hs
+++ b/src/Bound/TH.hs
@@ -385,8 +385,6 @@ getPure _name tyvr cons= do
 #endif
 
   return (findReturn lastTyVar (allTypeArgs `fmap` cons))
-#else
-#endif
 
 -------------------------------------------------------------------------------
 -- Type mangling
@@ -399,3 +397,5 @@ typeVars = map tvName
 -- | Apply arguments to a type constructor.
 conAppsT :: Name -> [Type] -> Type
 conAppsT conName = foldl AppT (ConT conName)
+#else
+#endif


### PR DESCRIPTION
Only depend on the `template-haskell` library when the corresponding `cabal` flag is enabled. In addition, test this in CI.

Fixes #85.