### PR TITLE
Make `Simple` example build with `base-4.18.*` (GHC 9.6)

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,7 @@
+next [????.??.??]
+-----------------
+* Allow the examples to build with `base-4.18.*` (GHC 9.6).
+
 2.0.5 [2022.05.07]
 ------------------
 * Allow building with `transformers-0.6.*`.

--- a/examples/Simple.hs
+++ b/examples/Simple.hs
@@ -61,15 +61,17 @@ instance Monad Exp where
   Lam e    >>= f = Lam (e >>>= f)
   Let bs b >>= f = Let (map (>>>= f) bs) (b >>>= f)
 
-deriveEq1   ''Exp
-deriveOrd1  ''Exp
-deriveRead1 ''Exp
-deriveShow1 ''Exp
-
-instance Eq a => Eq (Exp a) where (==) = eq1
-instance Ord a => Ord (Exp a) where compare = compare1
-instance Show a => Show (Exp a) where showsPrec = showsPrec1
-instance Read a => Read (Exp a) where readsPrec = readsPrec1
+fmap concat $ sequence
+  [ deriveEq1   ''Exp
+  , deriveOrd1  ''Exp
+  , deriveRead1 ''Exp
+  , deriveShow1 ''Exp
+  , [d| instance Eq a => Eq (Exp a) where (==) = eq1
+        instance Ord a => Ord (Exp a) where compare = compare1
+        instance Show a => Show (Exp a) where showsPrec = showsPrec1
+        instance Read a => Read (Exp a) where readsPrec = readsPrec1
+      |]
+  ]
 
 -- | Compute the normal form of an expression
 nf :: Exp a -> Exp a

--- a/src/Bound.hs
+++ b/src/Bound.hs
@@ -45,15 +45,18 @@
 -- @
 --
 -- @
--- deriveEq1   ''Exp
--- deriveOrd1  ''Exp
--- deriveRead1 ''Exp
--- deriveShow1 ''Exp
+-- concat <$> sequence
+--   [ deriveEq1   ''Exp
+--   , deriveOrd1  ''Exp
+--   , deriveRead1 ''Exp
+--   , deriveShow1 ''Exp
 --
--- instance 'Eq' a   => 'Eq'   (Exp a) where (==) = eq1
--- instance 'Ord' a  => 'Ord'  (Exp a) where compare = compare1
--- instance 'Show' a => 'Show' (Exp a) where showsPrec = showsPrec1
--- instance 'Read' a => 'Read' (Exp a) where readsPrec = readsPrec1
+--   , [d| instance 'Eq' a   => 'Eq'   (Exp a) where (==) = eq1
+--         instance 'Ord' a  => 'Ord'  (Exp a) where compare = compare1
+--         instance 'Show' a => 'Show' (Exp a) where showsPrec = showsPrec1
+--         instance 'Read' a => 'Read' (Exp a) where readsPrec = readsPrec1
+--       |]
+--   ]
 -- @
 --
 -- @


### PR DESCRIPTION
`Eq1` now has a quantified `Eq` superclass as of `base-4.18.*`. A knock-on consequence of this change is that the TH-derived `Eq1` instance in the `Simple` example no longer compiles, as the corresponding `Eq` instance is defined in a separate top-level group than the `Eq` instance. A similar problem exists for the `Ord1`, `Read1`, and `Show1` instances.  In fact, this problem is not unique to the `Simple` example—it will affect any instance that follows the templates given in the Haddocks for `Bound` and `Bound.TH`, both of which make use of TH!

I have adapted to these changes by defining all of the TH-derived instances (e.g., the `Eq1` instances) in the same TH splice as the hand-written instances (e.g., the `Eq` instances). This is a bit of a heavy-handed solution, but I can't think of a better one given the restrictions that TH splices impose.